### PR TITLE
TTK-21861 InstallBundle: Removed extra unused 'defaults' parameter

### DIFF
--- a/src/Pumukit/InstallBundleBundle/Manipulator/RoutingManipulator.php
+++ b/src/Pumukit/InstallBundleBundle/Manipulator/RoutingManipulator.php
@@ -35,7 +35,7 @@ class RoutingManipulator extends Manipulator
      *
      * @throws \RuntimeException If bundle is already imported
      */
-    public function addResource($bundle, $format, $prefix = '/', $type = '', $path = 'routing', $defaults = [], $appendToEnd = false)
+    public function addResource($bundle, $format, $prefix = '/', $type = '', $path = 'routing', $appendToEnd = false)
     {
         $current = '';
         $code = sprintf("%s:\n", Container::underscore(substr($bundle, 0, -6)).('/' !== $prefix ? '_'.str_replace('/', '_', substr($prefix, 1)) : ''));


### PR DESCRIPTION
From #1150 
this change makes more sense as 'defaults' is not being used.
When merged, also merge 2.6.x into 2.7.x and upwards to include this fix.