### PR TITLE
User Deprecated: The doctrine.odm.mongodb.document_manager service is…

### DIFF
--- a/src/Pumukit/OpencastBundle/Command/OpencastListCommand.php
+++ b/src/Pumukit/OpencastBundle/Command/OpencastListCommand.php
@@ -44,7 +44,7 @@ EOT
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $this->clientService = $this->getContainer()->get('pumukit_opencast.client');
-        $this->dm = $this->getContainer()->get('doctrine.odm.mongodb.document_manager');
+        $this->dm = $this->getContainer()->get('doctrine_mongodb.odm.document_manager');
     }
 
     /**

--- a/src/Pumukit/WebTVBundle/Controller/MediaLibraryController.php
+++ b/src/Pumukit/WebTVBundle/Controller/MediaLibraryController.php
@@ -31,7 +31,7 @@ class MediaLibraryController extends Controller implements WebTVControllerInterf
         $templateTitle = $this->get('translator')->trans($templateTitle);
         $this->get('pumukit_web_tv.breadcrumbs')->addList($templateTitle, 'pumukit_webtv_medialibrary_index', ['sort' => $sort]);
 
-        $dm = $this->get('doctrine.odm.mongodb.document_manager');
+        $dm = $this->get('doctrine_mongodb.odm.document_manager');
         $array_tags = $this->container->getParameter('pumukit_web_tv.media_library.filter_tags');
         $tagRepository = $dm->getRepository(Tag::class);
         $selectionTags = $tagRepository->findBy(['cod' => ['$in' => $array_tags]]);

--- a/src/Pumukit/WebTVBundle/Controller/ModulesController.php
+++ b/src/Pumukit/WebTVBundle/Controller/ModulesController.php
@@ -226,7 +226,7 @@ class ModulesController extends Controller implements WebTVControllerInterface
             throw new NotFoundHttpException('Categories not found');
         }
 
-        $dm = $this->get('doctrine.odm.mongodb.document_manager');
+        $dm = $this->get('doctrine_mongodb.odm.document_manager');
 
         if ($sort) {
             if (is_array($categories)) {


### PR DESCRIPTION
… private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.